### PR TITLE
Correção Ticket #9

### DIFF
--- a/src/Cielo/Http/CurlOnlyPostHttpClient.php
+++ b/src/Cielo/Http/CurlOnlyPostHttpClient.php
@@ -11,7 +11,7 @@ final class CurlOnlyPostHttpClient implements OnlyPostHttpClientInterface
     /**
      * {@inheritDoc}
      */
-    public function __invoke($url, array $fields, array $headers = [])
+    public function __invoke($url, array $headers = [], array $fields)
     {
         $headers = array_map(
             function ($name, $value) {

--- a/src/Cielo/Http/OnlyPostHttpClientInterface.php
+++ b/src/Cielo/Http/OnlyPostHttpClientInterface.php
@@ -13,5 +13,5 @@ interface OnlyPostHttpClientInterface
      * @param  \string[] $headers
      * @return string
      */
-    public function __invoke($url, array $fields, array $headers = []);
+    public function __invoke($url, array $headers = [], array $fields);
 }


### PR DESCRIPTION
Depois de novos testes e de verificar a documentação completa do webservice, verifiquei que os métodos mágicos __invoke nos arquivos src/Cielo/Http/CurlOnlyPostHttpClient.php e src/Cielo/Http/OnlyPostHttpClientInterface.php estavam com seus parâmetros invertidos e ao executar o método "CurlOnlyPostHttpClient" em src/Cielo/Http/CurlOnlyPostHttpClient.php, o "cabeçario" e "campos" para o Post, por estarem invertidos, construíam uma requisição "mal formada" que por sua vez gera a resposta "400 - Bad Request"