### PR TITLE
Alterado método setHolder, verificação do Bin válido

### DIFF
--- a/src/Cielo/Transaction.php
+++ b/src/Cielo/Transaction.php
@@ -331,7 +331,7 @@ class Transaction
     {
         $this->holder = $holder;
 
-        if (($bin = substr($holder->getCreditCardNumber(), 0, 6)) !== false) {
+        if ($bin = substr($holder->getCreditCardNumber(), 0, 6)) {
             $this->setBin($bin);
         }
     }


### PR DESCRIPTION
Preciso utilizar Token nas transações então não informo o cartão no Holder, então ao criar transação o método ```setHolder``` é chamado e verifica se o inicio do cartão é de 6 números, porém o retorno da função ```substr``` começando com 0 sempre retornará uma string mesmo vazia, assim a condição de não ser false é mantida gerando o erro ao chamar ```setBin```
Fiz somente uma alteração na condição para verificar se existe um valor, em vez de verificar se o valor é "false".