### PR TITLE
Ajustes para instanciar authorization (débito)

### DIFF
--- a/src/Cielo/Cielo.php
+++ b/src/Cielo/Cielo.php
@@ -121,6 +121,15 @@ class Cielo
     {
         return new Capture($this->merchant, $tid);
     }
+    
+    /**
+     * @param  string      $tid
+     * @return Consultation
+     */
+    public function authorization($tid = null)
+    {
+        return new Authorization($this->merchant, $tid);
+    }
 
     /**
      * @param  string     $issuer
@@ -176,12 +185,12 @@ class Cielo
     }
 
     /**
-     * @param  Transaction $transaction
+     * @param  Consultation $transaction
      * @return Transaction
      * @throws CieloException se algum erro ocorrer com na requisição pela
      * autorização
      */
-    public function authorizationRequest(Transaction $transaction)
+    public function authorizationRequest(Consultation $transaction)
     {
         $serializer = new AuthorizationRequestSerializer();
 
@@ -274,4 +283,5 @@ class Cielo
 
         return $unserializer->unserialize($response);
     }
+
 }


### PR DESCRIPTION
Atualmente não encontramos uma forma na biblioteca de autorizar uma transação autenticada (para débito), portanto sugerimos alguns ajustes que foram testados e estão funcionando.

public function authorization: implementada possibilitando o acesso a este recurso.
public function authorizationRequest: injeção de dependência alterada para Consultation, não sendo necessário instanciar uma nova Transaction
