### PR TITLE
Falha ao validar cartão com token no PHP 7.0

### DIFF
--- a/src/Cielo/Transaction.php
+++ b/src/Cielo/Transaction.php
@@ -307,7 +307,7 @@ class Transaction
     {
         return $this->avs;
     }
-    
+
     /**
      * @return Token
      */
@@ -330,8 +330,9 @@ class Transaction
     public function setHolder(Holder $holder)
     {
         $this->holder = $holder;
+        $bin = substr($holder->getCreditCardNumber(), 0, 6);
 
-        if (($bin = substr($holder->getCreditCardNumber(), 0, 6)) !== false) {
+        if (!empty($bin)) {
             $this->setBin($bin);
         }
     }

--- a/tests/Cielo/TransactionTest.php
+++ b/tests/Cielo/TransactionTest.php
@@ -162,4 +162,10 @@ class TransactionTest extends TestCase
 
         $this->transaction->setGenerateToken(0);
     }
+
+    public function testSetHolder_shouldBeSuccess_whenHolderHasToken()
+    {
+        $holder = new Holder('TuS6LeBHWjqFFtE7S3zR052Jl/KUlD+tYJFpAdlA87E=');
+        $this->transaction->setHolder($holder);
+    }
 }


### PR DESCRIPTION
No PHP 7, quando criamos uma _transaction_ utilizando um token válido de cartão, a verificação do conteúdo de `$bin` retorna `True` mesmo com o valor vazio.

O trecho `substr($holder->getCreditCardNumber(), 0, 6)` retorna uma string vazia ao invés do falor `False` esperado. Por consequência o método `setBin($bin)` é chamado, gerando gerando a exceção `O campo bin deve ser informado com os 6 primeiros dígitos do número do cartão.`

## Tests

Teste unitário que valida a correção pode ser executado via o seguinte comando:
```php
phpunit --filter testSetHolder_shouldBeSuccess_whenHolderHasToken
```