### PR TITLE
Cancelamento e captura parcial

### DIFF
--- a/src/Cielo/Serializer/CancellationRequestSerializer.php
+++ b/src/Cielo/Serializer/CancellationRequestSerializer.php
@@ -70,6 +70,11 @@ class CancellationRequestSerializer extends RequestSerializer
 
         $requisicao->appendChild($this->createDadosEc($transaction, $document));
 
+        if( !empty($transaction->getOrder()->getTotal()) ) {
+            $valor = $document->createElement('valor', $transaction->getOrder()->getTotal());
+            $requisicao->appendChild($valor);
+        }
+
         return $requisicao;
     }
 }

--- a/src/Cielo/Serializer/CaptureRequestSerializer.php
+++ b/src/Cielo/Serializer/CaptureRequestSerializer.php
@@ -70,6 +70,11 @@ class CaptureRequestSerializer extends RequestSerializer
 
         $requisicao->appendChild($this->createDadosEc($transaction, $document));
 
+        if( !empty($transaction->getOrder()->getTotal()) ) {
+            $valor = $document->createElement('valor', $transaction->getOrder()->getTotal());
+            $requisicao->appendChild($valor);
+        }
+
         return $requisicao;
     }
 }


### PR DESCRIPTION
Permite cancelar e capturar transações parcialmente passando o valor no order

$cancellation = $cielo->Cancellation( $tid );
$order = $cielo->order(  $num_pedido , $valor  );
$cancellation->setOrder($order);

$capture= $cielo->Capture( $tid );
$order = $cielo->order(  $num_pedido , $valor  );
$capture->setOrder($order);